### PR TITLE
Add function Set Read

### DIFF
--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
@@ -144,6 +144,22 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, N
                 result.success(messagesJson)
             }
 
+            "setRead" -> {
+                // Mandatory "messageId" parameter
+                val messageId = call.argument<String>("messageId")
+                // Find message from inbox
+                val message = IterableApi.getInstance().inAppManager.inboxMessages.firstOrNull {
+                    it.messageId == messageId
+                }
+                // Set message as read 
+                message?.let {
+                    IterableApi.getInstance().inAppManager.setRead(message, true)
+                    result.success(true) 
+                } ?: run {
+                    result.success(false)
+                }
+            }
+
             "showInboxMessage" -> {
                 // Mandatory "messageId" parameter
                 val messageId = call.argument<String>("messageId")

--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -96,6 +96,18 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin {
                 return message != nil ?  String(data: message! , encoding: .utf8) ?? "" : ""
             }
             result(messagesString)
+        case "setRead":
+
+            // Mandatory "messageId" parameter
+            let args = getPropertiesFromArguments(call.arguments)
+            
+            if let messageId = args["messageId"] as? String  ,  let iterableInAppMessage = IterableAPI.inAppManager.getMessage(withId: messageId) {
+                //Set Message as Read
+                IterableAPI.inAppManager.setRead(read: true, forMessage: iterableInAppMessage)
+                result(true)
+            } else {
+                result(false)
+            }
         case "showInboxMessage":
             
             // Mandatory "messageId" parameter

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -117,6 +117,15 @@ class IterableFlutter {
     return result;
   }
 
+  Future<void> setRead({required String messageId}) async {
+    await _channel.invokeMethod(
+      'setRead',
+      {
+        'messageId': messageId,
+      },
+    );
+  }
+
   Future<bool> deleteInboxMessage({required String messageId}) async {
     final result = await _channel.invokeMethod(
       'deleteInboxMessage',


### PR DESCRIPTION
This feature makes it easier to keep track of messages read. This function is needed because it triggers a message as read via IterableAPI does not process the recording of read messages [trackInAppOpen](https://api.iterable.com/api/docs#events_trackInAppOpen). This setRead function can be found in the sdk for [Swift](https://github.com/Iterable/swift-sdk/blob/master/swift-sdk/IterableInAppManagerProtocol.swift) and [Kotlin](https://github.com/Iterable/iterable-android-sdk/blob/master/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java#L131). 